### PR TITLE
fix: go.fmt was broken on some shells due to bad shell syntax

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -197,7 +197,7 @@ go.bumpdeps:
 go.fmt:
 	@set -e; for dir in $(GOMOD_DIRS); do ( set -xe; \
 	  cd $$dir; \
-	  $(GO) run golang.org/x/tools/cmd/goimports -w `go list -f '{{.Dir}}' ./...)` \
+	  $(GO) run golang.org/x/tools/cmd/goimports -w `go list -f '{{.Dir}}' ./...` \
 	); done
 
 VERIFY_STEPS += go.depaware-check


### PR DESCRIPTION
<!--
Thank you for your contribution to this repo!

Before submitting a pull request, please check the following:
- reference any related issue, PR, link
- use the "WIP" title prefix if you need help or more time to finish your PR

you can remove this markdown comment
-->